### PR TITLE
Added first launch procedure

### DIFF
--- a/app/src/main/java/com/example/boeing301house/MainActivity.java
+++ b/app/src/main/java/com/example/boeing301house/MainActivity.java
@@ -2,6 +2,7 @@ package com.example.boeing301house;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
 public class MainActivity extends AppCompatActivity {
@@ -10,5 +11,18 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        // regular procedure
+
+        // first launch procedure below (can also implement helper activity)
+        SharedPreferences pref = getSharedPreferences("mypref", MODE_PRIVATE);
+
+        if(pref.getBoolean("firststart",true)){
+            // after updating sharedpreferences it will not be triggered again
+            // uncomment next 3 lines when ready to update SharedPreferences
+//            SharedPreferences.Editor editor = pref.edit();
+//            editor.putBoolean("firststart", false);
+//            editor.commit(); // apply changes
+            // first launch procedure below (login screen)
+        }
     }
 }


### PR DESCRIPTION
Basic use of shared preferences to check for app's first launch

Currently disabled to allow testing of the fragment